### PR TITLE
Fix syntax error in CMD statement on last line of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,5 @@ EXPOSE 		3000
 RUN 		/bin/bash -l -c "gem install bundler --no-ri --no-rdoc && bundle install --without test development --with postgresql"
 ONBUILD 	RUN  /bin/bash -l -c "rake assets:precompile" # if you want to build downstream, assume diaspora.yml already exists
 
-CMD			['/bin/bash', '-l, '-c', '"bundle exec unicorn -c config/unicorn.rb"']
+#CMD			['/bin/bash', '-l, '-c', '"bundle exec unicorn -c config/unicorn.rb"']
+CMD			/bin/bash -l -c "bundle exec unicorn -c config/unicorn.rb"


### PR DESCRIPTION
You had an error in the last line of your Dockerfile as I was working my way through your video course.  The CMD statement had mismatched quotation marks.  For some reason, adding the missing quotation mark didn't fix it so I did away with the format of your CMD statement and replaced it with this one which appears to have fixed the problem.  I'm early on in the course so if the error was intentional, ignore this request.  :)